### PR TITLE
Add support for EGL_EXT_gl_colorspace_bt2020_pq

### DIFF
--- a/ios/xcode/MGLKit/MGLKView.h
+++ b/ios/xcode/MGLKit/MGLKView.h
@@ -34,6 +34,7 @@
 @property(nonatomic) MGLDrawableStencilFormat drawableStencilFormat;  // Default is StencilNone
 @property(nonatomic)
     MGLDrawableMultisample drawableMultisample;  // Default is MGLDrawableMultisampleNone
+@property(nonatomic) MGLDrawableColorSpace drawableColorSpace; // Default is ColorSpaceUnspecified
 
 // Return the size of the OpenGL default framebuffer.
 @property(readonly) CGSize drawableSize;

--- a/ios/xcode/MGLKit/MGLKView.mm
+++ b/ios/xcode/MGLKit/MGLKView.mm
@@ -105,6 +105,11 @@ void Throw(NSString *msg)
     self.glLayer.drawableMultisample = _drawableMultisample = drawableMultisample;
 }
 
+- (void)setDrawableColorSpace:(MGLDrawableColorSpace)drawableColorSpace
+{
+    self.glLayer.drawableColorSpace = _drawableColorSpace = drawableColorSpace;
+}
+
 - (void)display
 {
     [self drawRect:self.bounds];

--- a/ios/xcode/MGLKit/MGLLayer.h
+++ b/ios/xcode/MGLKit/MGLLayer.h
@@ -23,6 +23,7 @@ typedef enum MGLDrawableColorFormat : int
     MGLDrawableColorFormatRGBA8888  = 32,
     MGLDrawableColorFormatSRGBA8888 = -32,
     MGLDrawableColorFormatRGB565    = 16,
+    MGLDrawableColorFormatRGBA16    = 64,
 } MGLDrawableColorFormat;
 
 typedef enum MGLDrawableStencilFormat : int
@@ -44,6 +45,14 @@ typedef enum MGLDrawableMultisample : int
     MGLDrawableMultisample4X   = 4,
 } MGLDrawableMultisample;
 
+typedef enum MGLDrawableColorSpace : int
+{
+    MGLDrawableColorSpaceUnspecified = 0,
+    MGLDrawableColorSpaceLinear      = 1,
+    MGLDrawableColorSpaceSRGB        = 2,
+    MGLDrawableColorSpaceBT2020PQ    = 2020,
+} MGLDrawableColorSpace;
+
 @interface MGLLayer : CALayer
 
 // Return the size of the OpenGL framebuffer.
@@ -57,6 +66,7 @@ typedef enum MGLDrawableMultisample : int
 @property(nonatomic) MGLDrawableStencilFormat drawableStencilFormat;  // Default is StencilNone
 @property(nonatomic)
     MGLDrawableMultisample drawableMultisample;  // Default is MGLDrawableMultisampleNone
+@property(nonatomic) MGLDrawableColorSpace drawableColorSpace; // Default is ColorSpaceUnspecified
 
 // Default value is NO. Setting to YES will keep the framebuffer data after presenting.
 // Doing so will reduce performance and increase memory usage.

--- a/ios/xcode/MGLKit/MGLLayer.mm
+++ b/ios/xcode/MGLKit/MGLLayer.mm
@@ -347,6 +347,7 @@ GLint LinkProgram(GLuint program)
     _drawableDepthFormat   = MGLDrawableDepthFormatNone;
     _drawableStencilFormat = MGLDrawableStencilFormatNone;
     _drawableMultisample   = MGLDrawableMultisampleNone;
+    _drawableColorSpace    = MGLDrawableColorSpaceUnspecified;
 
     _display = [MGLDisplay defaultDisplay];
 
@@ -709,6 +710,18 @@ GLint LinkProgram(GLuint program)
         case MGLDrawableColorFormatSRGBA8888:
             red = green = blue = alpha = 8;
             colorSpace                 = EGL_GL_COLORSPACE_SRGB_KHR;
+            break;
+        case MGLDrawableColorFormatRGBA16:
+            red = green = blue = alpha = 16;
+            switch (_drawableColorSpace)
+            {
+                case MGLDrawableColorSpaceBT2020PQ:
+                    colorSpace = EGL_GL_COLORSPACE_BT2020_PQ_EXT;
+                    break;
+                default:
+                    colorSpace = EGL_GL_COLORSPACE_LINEAR_KHR;
+                    break;
+            }
             break;
         default:
             UNREACHABLE();

--- a/src/libANGLE/Caps.cpp
+++ b/src/libANGLE/Caps.cpp
@@ -1222,6 +1222,8 @@ std::vector<std::string> DisplayExtensions::getStrings() const
     InsertExtensionString("EGL_EXT_gl_colorspace_display_p3",                    glColorspaceDisplayP3,              &extensionStrings);
     InsertExtensionString("EGL_EXT_gl_colorspace_display_p3_linear",             glColorspaceDisplayP3Linear,        &extensionStrings);
     InsertExtensionString("EGL_EXT_gl_colorspace_display_p3_passthrough",        glColorspaceDisplayP3Passthrough,   &extensionStrings);
+    InsertExtensionString("EGL_EXT_gl_colorspace_bt2020_linear",                 glColorspaceBT2020,                 &extensionStrings);
+    InsertExtensionString("EGL_EXT_gl_colorspace_bt2020_pq",                     glColorspaceBT2020PQ,               &extensionStrings);
     InsertExtensionString("EGL_KHR_gl_texture_2D_image",                         glTexture2DImage,                   &extensionStrings);
     InsertExtensionString("EGL_KHR_gl_texture_cubemap_image",                    glTextureCubemapImage,              &extensionStrings);
     InsertExtensionString("EGL_KHR_gl_texture_3D_image",                         glTexture3DImage,                   &extensionStrings);

--- a/src/libANGLE/Caps.h
+++ b/src/libANGLE/Caps.h
@@ -961,6 +961,12 @@ struct DisplayExtensions
 
     // EGL_EXT_gl_colorspace_display_p3_passthrough
     bool glColorspaceDisplayP3Passthrough = false;
+
+    // EGL_EXT_gl_colorspace_bt2020_linear
+    bool glColorspaceBT2020 = false;
+
+    // EGL_EXT_gl_colorspace_bt2020_pq
+    bool glColorspaceBT2020PQ = false;
 };
 
 struct DeviceExtensions

--- a/src/libANGLE/renderer/gl/egl/DisplayEGL.cpp
+++ b/src/libANGLE/renderer/gl/egl/DisplayEGL.cpp
@@ -149,6 +149,10 @@ void DisplayEGL::generateExtensions(egl::DisplayExtensions *outExtensions) const
             mEGL->hasExtension("EGL_EXT_gl_colorspace_scrgb_linear");
         outExtensions->glColorspaceDisplayP3Passthrough =
             mEGL->hasExtension("EGL_EXT_gl_colorspace_display_p3_passthrough");
+        outExtensions->glColorspaceBT2020 =
+            mEGL->hasExtension("EGL_EXT_gl_colorspace_bt2020_linear");
+        outExtensions->glColorspaceBT2020PQ =
+            mEGL->hasExtension("EGL_EXT_gl_colorspace_bt2020_pq");
     }
 
     outExtensions->imageNativeBuffer = mEGL->hasExtension("EGL_ANDROID_image_native_buffer");

--- a/src/libANGLE/renderer/metal/DisplayMtl.mm
+++ b/src/libANGLE/renderer/metal/DisplayMtl.mm
@@ -238,6 +238,7 @@ void DisplayMtl::generateExtensions(egl::DisplayExtensions *outExtensions) const
     outExtensions->fenceSync                    = true;
     outExtensions->waitSync                     = true;
     outExtensions->glColorspace                 = true;
+    outExtensions->glColorspaceBT2020PQ         = true;
 }
 
 void DisplayMtl::generateCaps(egl::Caps *outCaps) const {}

--- a/src/libANGLE/renderer/metal/SurfaceMtl.mm
+++ b/src/libANGLE/renderer/metal/SurfaceMtl.mm
@@ -206,6 +206,13 @@ SurfaceMtl::SurfaceMtl(DisplayMtl *display,
     {
         mColorFormat = display->getPixelFormat(angle::FormatID::B8G8R8A8_UNORM_SRGB);
     }
+    else if (attribs.get(EGL_GL_COLORSPACE, EGL_GL_COLORSPACE_LINEAR) == EGL_GL_COLORSPACE_BT2020_PQ_EXT)
+    {
+        mColorFormat.intendedFormatId = mColorFormat.actualFormatId =
+            angle::FormatID::R16G16B16A16_FLOAT;
+        mColorFormat.metalFormat = MTLPixelFormatRGBA16Float;
+        mColorFormat.metalColorspace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020_PQ);
+    }
     else
     {
         // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf says that BGRA8Unorm is
@@ -302,6 +309,7 @@ egl::Error SurfaceMtl::initialize(const egl::Display *display)
 
         mMetalLayer.get().device          = metalDevice;
         mMetalLayer.get().pixelFormat     = mColorFormat.metalFormat;
+        mMetalLayer.get().colorspace      = mColorFormat.metalColorspace;
         mMetalLayer.get().framebufferOnly = NO;  // Support blitting and glReadPixels
 
 #if TARGET_OS_OSX || TARGET_OS_MACCATALYST

--- a/src/libANGLE/renderer/metal/mtl_format_utils.h
+++ b/src/libANGLE/renderer/metal/mtl_format_utils.h
@@ -12,6 +12,7 @@
 #define LIBANGLE_RENDERER_METAL_MTL_FORMAT_UTILS_H_
 
 #import <Metal/Metal.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 #include <unordered_map>
 
@@ -81,6 +82,7 @@ struct Format : public FormatBase
     bool needConversion(angle::FormatID srcFormatId) const;
 
     MTLPixelFormat metalFormat = MTLPixelFormatInvalid;
+    CGColorSpaceRef metalColorspace = nil;
 
     LoadFunctionMap textureLoadFunctions       = nullptr;
     InitializeTextureDataFunction initFunction = nullptr;


### PR DESCRIPTION
WIP. Wired up the EGL_EXT_gl_colorspace_bt2020 extension, but have not tested it yet.

I'm not so sure about the public MGLKit API to expose this. I may decide to use `eglCreateWindowSurface` directly in my app and remove the `MGLDrawableColorSpace`/`MGLDrawableColorFormat` changes here.