### PR TITLE
Update .gitignore to avoid xcode user settings

### DIFF
--- a/ios/xcode/.gitignore
+++ b/ios/xcode/.gitignore
@@ -1,1 +1,2 @@
 /gen
+*xcuser*/


### PR DESCRIPTION
Xcode creates xcuserdata, xcuserstate directories which has some stuff which isn't shared, but rather user customizations and should be excluded from the repo. Just quality of life improvement, no code changes.