### PR TITLE
implement isPaused, pauseOnWillResignActive, resumeOnDidBecomeActive

### DIFF
--- a/ios/xcode/MGLKit/MGLKViewController+Mac.mm
+++ b/ios/xcode/MGLKit/MGLKViewController+Mac.mm
@@ -105,9 +105,11 @@ static CVReturn CVFrameDisplayCallback(CVDisplayLinkRef displayLink,
 
 - (void)pause
 {
+    if (_isPaused)
+    {
+        return;
+    }
     NSLog(@"MGLKViewController pause");
-
-    _isPaused = YES;
 
     if (_displayLink)
     {
@@ -118,14 +120,19 @@ static CVReturn CVFrameDisplayCallback(CVDisplayLinkRef displayLink,
         [_displayTimer invalidate];
         _displayTimer = nil;
     }
+
+    _isPaused = YES;
 }
 
 - (void)resume
 {
+    if (!_isPaused)
+    {
+        return;
+    }
+
     [self pause];
     NSLog(@"MGLKViewController resume");
-
-    _isPaused = NO;
 
     if (!_glView)
     {
@@ -188,4 +195,6 @@ static CVReturn CVFrameDisplayCallback(CVDisplayLinkRef displayLink,
         [[NSRunLoop currentRunLoop] addTimer:_displayTimer forMode:NSDefaultRunLoopMode];
         [[NSRunLoop currentRunLoop] addTimer:_displayTimer forMode:NSModalPanelRunLoopMode];
     }
+
+    _isPaused = NO;
 }

--- a/ios/xcode/MGLKit/MGLKViewController+Mac.mm
+++ b/ios/xcode/MGLKit/MGLKViewController+Mac.mm
@@ -106,6 +106,9 @@ static CVReturn CVFrameDisplayCallback(CVDisplayLinkRef displayLink,
 - (void)pause
 {
     NSLog(@"MGLKViewController pause");
+
+    _isPaused = YES;
+
     if (_displayLink)
     {
         CVDisplayLinkStop(_displayLink);
@@ -121,6 +124,8 @@ static CVReturn CVFrameDisplayCallback(CVDisplayLinkRef displayLink,
 {
     [self pause];
     NSLog(@"MGLKViewController resume");
+
+    _isPaused = NO;
 
     if (!_glView)
     {

--- a/ios/xcode/MGLKit/MGLKViewController+iOS.mm
+++ b/ios/xcode/MGLKit/MGLKViewController+iOS.mm
@@ -35,6 +35,9 @@
 - (void)pause
 {
     NSLog(@"MGLKViewController pause");
+
+    _isPaused = YES;
+
     if (_displayLink)
     {
         [_displayLink removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
@@ -46,6 +49,8 @@
 {
     [self pause];
     NSLog(@"MGLKViewController resume");
+
+    _isPaused = NO;
 
     if (!_glView)
     {

--- a/ios/xcode/MGLKit/MGLKViewController+iOS.mm
+++ b/ios/xcode/MGLKit/MGLKViewController+iOS.mm
@@ -34,23 +34,31 @@
 
 - (void)pause
 {
-    NSLog(@"MGLKViewController pause");
+    if (_isPaused)
+    {
+        return;
+    }
 
-    _isPaused = YES;
+    NSLog(@"MGLKViewController pause");
 
     if (_displayLink)
     {
         [_displayLink removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
         _displayLink = nil;
     }
+
+    _isPaused = YES;
 }
 
 - (void)resume
 {
+    if (!_isPaused)
+    {
+        return;
+    }
+
     [self pause];
     NSLog(@"MGLKViewController resume");
-
-    _isPaused = NO;
 
     if (!_glView)
     {
@@ -71,4 +79,6 @@
     }
 
     [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+
+    _isPaused = NO;
 }

--- a/ios/xcode/MGLKit/MGLKViewController.h
+++ b/ios/xcode/MGLKit/MGLKViewController.h
@@ -31,6 +31,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSInteger framesDisplayed;
 @property(nonatomic, readonly) NSTimeInterval timeSinceLastUpdate;
 
+@property(nonatomic) bool isPaused;
+@property(nonatomic) bool pauseOnWillResignActive;
+@property(nonatomic) bool resumeOnDidBecomeActive;
+
 @property(weak, nonatomic, readonly) MGLKView *glView;
 
 @end

--- a/ios/xcode/MGLKit/MGLKViewController.mm
+++ b/ios/xcode/MGLKit/MGLKViewController.mm
@@ -55,6 +55,8 @@
 {
     _appWasInBackground       = YES;
     _preferredFramesPerSecond = 30;
+    _pauseOnWillResignActive  = YES;
+    _resumeOnDidBecomeActive  = YES;
 }
 
 - (void)dealloc
@@ -92,6 +94,17 @@
             _glView.controller = nil;
         }
         _glView = nil;
+    }
+}
+
+- (void)setIsPaused:(bool)isPaused
+{
+    if (isPaused != _isPaused) {
+        if (isPaused) {
+            [self pause];
+        } else {
+            [self resume];
+        }
     }
 }
 
@@ -156,14 +169,18 @@
 - (void)appWillPause:(NSNotification *)note
 {
     NSLog(@"MGLKViewController appWillPause:");
-    _appWasInBackground = YES;
-    [self pause];
+    if (_pauseOnWillResignActive) {
+        _appWasInBackground = YES;
+        [self pause];
+    }
 }
 
 - (void)appDidBecomeActive:(NSNotification *)note
 {
     NSLog(@"MGLKViewController appDidBecomeActive:");
-    [self resume];
+    if (_resumeOnDidBecomeActive) {
+        [self resume];
+    }
 }
 
 - (void)handleAppWasInBackground

--- a/ios/xcode/MGLKit/MGLKViewController.mm
+++ b/ios/xcode/MGLKit/MGLKViewController.mm
@@ -57,6 +57,8 @@
     _preferredFramesPerSecond = 30;
     _pauseOnWillResignActive  = YES;
     _resumeOnDidBecomeActive  = YES;
+    // not-paused corresponds to having a DisplayLink or timer active and driving the frame loop
+    _isPaused                 = YES;
 }
 
 - (void)dealloc


### PR DESCRIPTION
In my app I needed to disable the automatic pause-when-not-active behavior so I've implemented the relevant flags from GLKViewController:

From [apple's docs](https://developer.apple.com/documentation/glkit/glkviewcontroller)

```
var isPaused: Bool
```
A Boolean value that indicates whether the rendering loop is paused.

```
var pauseOnWillResignActive: Bool
```
A Boolean value that indicates whether the view controller automatically pauses the rendering loop when the application resigns the active state.

```
var resumeOnDidBecomeActive: Bool
```
A Boolean value that indicates whether the view controller automatically resumes the rendering loop when the application becomes active.