### PR TITLE
Use weak reference to break the retain cycle between MGLContext and MGLSharegroup

### DIFF
--- a/ios/xcode/MGLKit/MGLContext.mm
+++ b/ios/xcode/MGLKit/MGLContext.mm
@@ -66,7 +66,7 @@ void Throw(NSString *msg)
 
 // MGLSharegroup implementation
 @interface MGLSharegroup ()
-@property(atomic) MGLContext *firstContext;
+@property(atomic, weak) MGLContext *firstContext;
 @end
 
 @implementation MGLSharegroup


### PR DESCRIPTION
Addresses https://github.com/kakashidinho/metalangle/issues/50 .

Make the `firstContext` property of `MGLSharegroup` use a weak reference to break the retain cycle between `MGLContext` and `MGLSharegroup`.