### PR TITLE
Make `pauseOnWillResignActive` and `resumeOnDidBecomeActive` behavior match GLKit

### DIFF
--- a/ios/xcode/MGLKit/MGLKViewController+Mac.mm
+++ b/ios/xcode/MGLKit/MGLKViewController+Mac.mm
@@ -106,7 +106,7 @@ static CVReturn CVFrameDisplayCallback(CVDisplayLinkRef displayLink,
 
 - (void)pause
 {
-    if (_isPaused)
+    if (_paused)
     {
         return;
     }
@@ -122,12 +122,12 @@ static CVReturn CVFrameDisplayCallback(CVDisplayLinkRef displayLink,
         _displayTimer = nil;
     }
 
-    _isPaused = YES;
+    _paused = YES;
 }
 
 - (void)resume
 {
-    if (!_isPaused)
+    if (!_paused)
     {
         return;
     }
@@ -197,5 +197,5 @@ static CVReturn CVFrameDisplayCallback(CVDisplayLinkRef displayLink,
         [[NSRunLoop currentRunLoop] addTimer:_displayTimer forMode:NSModalPanelRunLoopMode];
     }
 
-    _isPaused = NO;
+    _paused = NO;
 }

--- a/ios/xcode/MGLKit/MGLKViewController+iOS.mm
+++ b/ios/xcode/MGLKit/MGLKViewController+iOS.mm
@@ -34,7 +34,7 @@
 
 - (void)pause
 {
-    if (_isPaused)
+    if (_paused)
     {
         return;
     }
@@ -47,12 +47,12 @@
         _displayLink = nil;
     }
 
-    _isPaused = YES;
+    _paused = YES;
 }
 
 - (void)resume
 {
-    if (!_isPaused)
+    if (!_paused)
     {
         return;
     }
@@ -86,5 +86,5 @@
 
     [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
 
-    _isPaused = NO;
+    _paused = NO;
 }

--- a/ios/xcode/MGLKit/MGLKViewController.h
+++ b/ios/xcode/MGLKit/MGLKViewController.h
@@ -31,8 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSInteger framesDisplayed;
 @property(nonatomic, readonly) NSTimeInterval timeSinceLastUpdate;
 
-@property(nonatomic) BOOL isPaused;
-@property(nonatomic, setter=setIsPaused:) BOOL paused;
+@property(nonatomic) BOOL paused;
 @property(nonatomic) BOOL pauseOnWillResignActive;
 @property(nonatomic) BOOL resumeOnDidBecomeActive;
 

--- a/ios/xcode/MGLKit/MGLKViewController.h
+++ b/ios/xcode/MGLKit/MGLKViewController.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSInteger framesDisplayed;
 @property(nonatomic, readonly) NSTimeInterval timeSinceLastUpdate;
 
-@property(nonatomic) BOOL paused;
+@property(nonatomic, getter=isPaused) BOOL paused;
 @property(nonatomic) BOOL pauseOnWillResignActive;
 @property(nonatomic) BOOL resumeOnDidBecomeActive;
 

--- a/ios/xcode/MGLKit/MGLKViewController.mm
+++ b/ios/xcode/MGLKit/MGLKViewController.mm
@@ -58,7 +58,7 @@
     _pauseOnWillResignActive  = YES;
     _resumeOnDidBecomeActive  = YES;
     // not-paused corresponds to having a DisplayLink or timer active and driving the frame loop
-    _paused                 = YES;
+    _paused                   = YES;
 }
 
 - (void)dealloc

--- a/ios/xcode/MGLKit/MGLKViewController.mm
+++ b/ios/xcode/MGLKit/MGLKViewController.mm
@@ -58,7 +58,7 @@
     _pauseOnWillResignActive  = YES;
     _resumeOnDidBecomeActive  = YES;
     // not-paused corresponds to having a DisplayLink or timer active and driving the frame loop
-    _isPaused                 = YES;
+    _paused                 = YES;
 }
 
 - (void)dealloc
@@ -99,20 +99,15 @@
     }
 }
 
-- (void)setIsPaused:(BOOL)isPaused
+- (void)setPaused:(BOOL)paused
 {
-    if (isPaused != _isPaused) {
-        if (isPaused) {
+    if (paused != _paused) {
+        if (paused) {
             [self pause];
         } else {
             [self resume];
         }
     }
-}
-
-- (BOOL)paused
-{
-    return _isPaused;
 }
 
 - (void)mglkView:(MGLKView *)view drawInRect:(CGRect)rect

--- a/ios/xcode/MGLKit/MGLKViewController.mm
+++ b/ios/xcode/MGLKit/MGLKViewController.mm
@@ -173,7 +173,7 @@
     NSLog(@"MGLKViewController appWillPause:");
     if (_pauseOnWillResignActive) {
         _appWasInBackground = YES;
-        [self pause];
+        self.paused = YES;
     }
 }
 
@@ -181,7 +181,7 @@
 {
     NSLog(@"MGLKViewController appDidBecomeActive:");
     if (_resumeOnDidBecomeActive) {
-        [self resume];
+        self.paused = NO;
     }
 }
 


### PR DESCRIPTION
The `paused`, `pauseOnWillResignActive`, and `resumeOnDidBecomeActive` properties implemented in https://github.com/kakashidinho/metalangle/pull/41 work very well overall, but I noticed an issue with them in an app I work on.  The app previously used a `GLKViewController`, which I've replaced with an `MGLKViewController`.  After the replacement, some functionality that relied on `pauseOnWillResignActive` and `resumeOnDidBecomeActive` stopped working properly.

I did some investigation and figured out that a subtle difference in behavior is to blame.  When an app displaying a `GLKViewController` resigns active state or becomes active, the view controller calls its `setPaused:` method.  This is important because the app may override `setPaused:` to trigger other functionality.  Currently `MGLKViewController` pauses and resumes itself in this situation without ever calling `setPaused:`, so this PR changes it to match the behavior of GLKit.

As mentioned in the comments of https://github.com/kakashidinho/metalangle/pull/41 , the `isPaused` property of `GLKViewController` is actually named `paused`.  This PR changes the property name in `MGLKViewController` to match GLKit as well.