### PR TITLE
Build script compatibility with macOS 12 Monterey

### DIFF
--- a/ios/xcode/OpenGLES.xcodeproj/project.pbxproj
+++ b/ios/xcode/OpenGLES.xcodeproj/project.pbxproj
@@ -10176,7 +10176,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "python ${PROJECT_DIR}/../../src/commit_id.py \\\n    gen \\\n    ${PROJECT_DIR}/../.. \\\n    ${PROJECT_DIR}/gen/id/commit.h\n";
+			shellScript = "${PROJECT_DIR}/../../src/commit_id.sh \\\n    gen \\\n    ${PROJECT_DIR}/../.. \\\n    ${PROJECT_DIR}/gen/id/commit.h\n";
 		};
 		0AF95996244C7CD700F59740 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/src/commit_id.sh
+++ b/src/commit_id.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#  Copyright 2018 The ANGLE Project Authors. All rights reserved.
+#  Use of this source code is governed by a BSD-style license that can be
+#  found in the LICENSE file.
+
+# Generate commit.h with git commit hash.
+#
+
+set -e
+
+function usage {
+    echo 'Usage: commit_id.sh check <angle_dir>                - check if git is present'
+    echo '       commit_id.sh gen <angle_dir> <file_to_write>  - generate commit.h'
+}
+
+if [ "$#" -lt 2 ]
+then
+    usage
+    exit 1
+fi
+
+d="$2"
+
+if [ "$1" == "check" ]
+then
+    if [ -f "$d/.git/index" ]
+    then
+        echo 1
+    else
+        echo 0
+    fi
+elif [ "$1" == "gen" ]
+then
+    if [ ! "$3" ]
+    then
+        usage
+        exit 1
+    fi
+    output="$(cd "$(dirname "$3")"; pwd -P)/$(basename "$3")"
+    
+    (
+        set +e
+        cd "$d"
+        commit_id_size=12
+        commit_id=$(git rev-parse --short=$commit_id_size HEAD 2>/dev/null)
+        commit_date=$(git show -s --format=%ci HEAD 2>/dev/null)
+
+        echo '#define ANGLE_COMMIT_HASH "'"${commit_id:-invalid-hash}"'"' > "$output"
+        echo '#define ANGLE_COMMIT_HASH_SIZE '"$commit_id_size" >> "$output"
+        echo '#define ANGLE_COMMIT_DATE "'"${commit_date:-invalid-date}"'"' >> "$output"
+
+    )
+else
+    usage
+    exit 2
+fi


### PR DESCRIPTION
Monterey removed `python` so I rewrote the script in bash. Luckily it is rather simple.