### PR TITLE
Disable zoom on startup

### DIFF
--- a/ios/xcode/MGLKit/MGLLayer+Private.h
+++ b/ios/xcode/MGLKit/MGLLayer+Private.h
@@ -10,6 +10,7 @@
 #import "MGLLayer.h"
 
 #import <QuartzCore/CAMetalLayer.h>
+#import <QuartzCore/QuartzCore.h>
 
 #include <EGL/egl.h>
 #include <GLES2/gl2.h>

--- a/ios/xcode/MGLKit/MGLLayer.mm
+++ b/ios/xcode/MGLKit/MGLLayer.mm
@@ -680,10 +680,14 @@ GLint LinkProgram(GLuint program)
     if (rx::IsMetalDisplayAvailable())
     {
         // Resize the metal layer
+        [CATransaction begin];
+        [CATransaction setValue:(id)kCFBooleanTrue
+                         forKey:kCATransactionDisableActions];
         _metalLayer.frame = self.bounds;
         _metalLayer.drawableSize =
             CGSizeMake(_metalLayer.bounds.size.width * _metalLayer.contentsScale,
                        _metalLayer.bounds.size.height * _metalLayer.contentsScale);
+        [CATransaction commit];
     }
     else
     {


### PR DESCRIPTION
This fixes https://github.com/kakashidinho/metalangle/issues/49

A lot of people on libGDX complained about the "zoom in" on the startup of any iOS App. This disables the zooming and makes opening of the app looking cleaner.